### PR TITLE
Add RetryContext during resource creation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,17 +32,6 @@ steps:
       CB_PASSWORD: 123456
       CB_USERNAME: Administrator
 
-  - name: release
-    image: goreleaser/goreleaser
-    commands:
-      - goreleaser release
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    when:
-      event:
-        - tag
-
 services:
   - name: couchbase
     image: couchbase
@@ -62,6 +51,6 @@ trigger:
 
 ---
 kind: signature
-hmac: a604c1918bf81e413e1c528bab1a3319bddbaad567f10775738ffc5b08d1bd9a
+hmac: 17e04823149f7f9b47046dcb6c51fb0fa7489d151894a6b0afeba538bd444b74
 
 ...

--- a/couchbase/constants.go
+++ b/couchbase/constants.go
@@ -58,5 +58,8 @@ const (
 	keyQueryIndexCondition  = "condition"
 
 	// Others
-	queryIndexTimeoutCreate = 300
+	queryIndexTimeoutCreate    = 300
+	bucketTimeoutCreate        = 300
+	securityUserTimeoutCreate  = 300
+	securityGroupTimeoutCreate = 300
 )

--- a/docs/resources/bucket_manager.md
+++ b/docs/resources/bucket_manager.md
@@ -1,7 +1,6 @@
 ---
 layout: "couchbase"
 page_title: "terraform-provider-couchbase resource: couchbase_bucket_manager"
-subcategory: "docs-couchbase-resource-couchbase_bucket_manager"
 sidebar_current: "docs-couchbase-resource-couchbase_bucket_manager"
 description: |-
   Manage buckets in couchbase

--- a/docs/resources/primary_query_index.md
+++ b/docs/resources/primary_query_index.md
@@ -1,7 +1,6 @@
 ---
 layout: "couchbase"
 page_title: "terraform-provider-couchbase resource: couchbase_primary_query_index"
-subcategory: "docs-couchbase-resource-couchbase_primary_query_index"
 sidebar_current: "docs-couchbase-resource-couchbase_primary_query_index"
 description: |-
   Manage primary query indexex in couchbase

--- a/docs/resources/query_index.md
+++ b/docs/resources/query_index.md
@@ -1,7 +1,6 @@
 ---
 layout: "couchbase"
 page_title: "terraform-provider-couchbase resource: couchbase_query_index"
-subcategory: "docs-couchbase-resource-couchbase_query_index"
 sidebar_current: "docs-couchbase-resource-couchbase_query_index"
 description: |-
   Manage query indexex in couchbase

--- a/docs/resources/security_group.md
+++ b/docs/resources/security_group.md
@@ -1,7 +1,6 @@
 ---
 layout: "couchbase"
 page_title: "terraform-provider-couchbase resource: couchbase_security_group"
-subcategory: "docs-couchbase-resource-couchbase_security_group"
 sidebar_current: "docs-couchbase-resource-couchbase_security_group"
 description: |-
   Manage groups in couchbase

--- a/docs/resources/security_user.md
+++ b/docs/resources/security_user.md
@@ -1,7 +1,6 @@
 ---
 layout: "couchbase"
 page_title: "terraform-provider-couchbase resource: couchbase_security_user"
-subcategory: "docs-couchbase-resource-couchbase_security_user"
 sidebar_current: "docs-couchbase-resource-couchbase_security_user"
 description: |-
   Manage users in couchbase


### PR DESCRIPTION
Sometimes we need to wait until resource is create.
We add RetryContext for all resource during create process.

Fix documentation and pipeline.